### PR TITLE
Build order number unification between VS Output Build Pane/Window and Gantt chart

### DIFF
--- a/BuildInfo.cs
+++ b/BuildInfo.cs
@@ -11,10 +11,11 @@ namespace ParallelBuildsMonitor
     /// </summary>
     public struct BuildInfo
     {
-        public BuildInfo(string projectUniqueName, string projectName, long b, long e, bool s)
+        public BuildInfo(string projectUniqueName, string projectName, uint projectBuildOrderNumber, long b, long e, bool s)
         {
             ProjectUniqueName = projectUniqueName;
             ProjectName = projectName;
+            ProjectBuildOrderNumber = projectBuildOrderNumber;
             begin = b;
             end = e;
             success = s;
@@ -29,6 +30,11 @@ namespace ParallelBuildsMonitor
         /// Project name in human readable format
         /// </summary>
         public string ProjectName { get; set; } // Probably should be renamed to Name and BuildInfo into ProjectBuildInfo
+
+        /// <summary>
+        /// Project build order number, e.g. "1>..." that shows in the Output Build Pane/Window during build.
+        /// </summary>
+        public uint ProjectBuildOrderNumber { get; set; } // Probably should be renamed to BuildOrderNumber and BuildInfo into ProjectBuildInfo
 
         /// <summary>
         /// Start project building time in <c>DateTime.Ticks</c> units

--- a/GraphControl.cs
+++ b/GraphControl.cs
@@ -259,7 +259,7 @@ namespace ParallelBuildsMonitor
                             maxStringLength = l;
                         }
                     }
-                    foreach (KeyValuePair<string, DateTime> item in DataModel.CurrentBuilds)
+                    foreach (KeyValuePair<string, Tuple<uint, long>> item in DataModel.CurrentBuilds)
                     {
                         FormattedText iname = new FormattedText(item.Key, CultureInfo.CurrentCulture, FlowDirection.LeftToRight, fontFace, FontSize, blackBrush);
                         double l = iname.Width;
@@ -272,7 +272,7 @@ namespace ParallelBuildsMonitor
                     {
                         maxTick = (maxTick / tickStep + 1) * tickStep;
                     }
-                    FormattedText iint = new FormattedText(i.ToString(intFormat) + " ", CultureInfo.CurrentCulture, FlowDirection.LeftToRight, fontFace, FontSize, blackBrush);
+                    FormattedText iint = new FormattedText(i.ToString(intFormat) + "> ", CultureInfo.CurrentCulture, FlowDirection.LeftToRight, fontFace, FontSize, blackBrush);
                     maxStringLength += 5 + iint.Width;
 
                     i = 0;
@@ -302,7 +302,7 @@ namespace ParallelBuildsMonitor
                         Brush gradientBrush = item.success ? greenGradientBrush : redGradientBrush;
                         DateTime span = new DateTime(item.end - item.begin);
                         string time = Utils.SecondsToString(span.Ticks);
-                        FormattedText itext = new FormattedText((i).ToString(intFormat) + " " + item.ProjectName, CultureInfo.CurrentCulture, FlowDirection.LeftToRight, fontFace, FontSize, solidBrush);
+                        FormattedText itext = new FormattedText((item.ProjectBuildOrderNumber).ToString(intFormat) + "> " + item.ProjectName, CultureInfo.CurrentCulture, FlowDirection.LeftToRight, fontFace, FontSize, solidBrush);
                         drawingContext.DrawText(itext, new Point(1, i * rowHeight)); //Write project name
                         Rect r = new Rect();
                         r.X = maxStringLength + (int)((item.begin) * (long)(RenderSize.Width - maxStringLength) / maxTick);
@@ -336,12 +336,12 @@ namespace ParallelBuildsMonitor
                     }
 
                     Brush blueGradientBrush = new LinearGradientBrush(Colors.LightBlue, Colors.DarkBlue, new Point(0, 0), new Point(0, 1));
-                    foreach (KeyValuePair<string, DateTime> item in DataModel.CurrentBuilds)
+                    foreach (KeyValuePair<string, Tuple<uint, long>> item in DataModel.CurrentBuilds)
                     {
-                        FormattedText itext = new FormattedText((i).ToString(intFormat) + " " + DataModel.GetHumanReadableProjectName(item.Key), CultureInfo.CurrentCulture, FlowDirection.LeftToRight, fontFace, FontSize, blueSolidBrush);
+                        FormattedText itext = new FormattedText((item.Value.Item1).ToString(intFormat) + "> " + DataModel.GetHumanReadableProjectName(item.Key), CultureInfo.CurrentCulture, FlowDirection.LeftToRight, fontFace, FontSize, blueSolidBrush);
                         drawingContext.DrawText(itext, new Point(1, i * rowHeight));
                         Rect r = new Rect();
-                        r.X = maxStringLength + (int)((item.Value.Ticks - DataModel.StartTime.Ticks) * (long)(RenderSize.Width - maxStringLength) / maxTick);
+                        r.X = maxStringLength + (int)((item.Value.Item2) * (long)(RenderSize.Width - maxStringLength) / maxTick);
                         r.Width = maxStringLength + (int)((nowTick - DataModel.StartTime.Ticks) * (long)(RenderSize.Width - maxStringLength) / maxTick) - r.X;
                         if (r.Width == 0)
                         {


### PR DESCRIPTION
In fact, we should drop leading zeros, so it would be very clear that this is the same number

![unification](https://user-images.githubusercontent.com/37815148/51004692-0c4b6700-153c-11e9-8444-8661541a1861.png)
