### PR TITLE
Removing unnecesary GetService() call (Async part 2: Moving from GetService() to GetServiceAsync())

### DIFF
--- a/Plugin/GraphControl.cs
+++ b/Plugin/GraphControl.cs
@@ -336,11 +336,6 @@ namespace ParallelBuildsMonitor
                     if (PBMCommand.Instance == null)
                         return;
 
-                    DTE2 dte = (DTE2)PBMCommand.Instance.ServiceProvider.GetService(typeof(DTE));
-
-                    if (dte == null)
-                        return;
-
                     if (DataModel.Instance.AllProjectsCount == 0)
                         return;
 


### PR DESCRIPTION
All GetService() need to be migrated to GetServiceAsync(),
however I believe this call is unnecessary (tested - works OK without it)
IMO graph just should draw what is collected in DataModel object and do not interact with any VS API