### PR TITLE
VS 2026 support, target .NET 4.8 

### DIFF
--- a/Plugin/source.extension.vsixmanifest
+++ b/Plugin/source.extension.vsixmanifest
@@ -20,7 +20,7 @@
     </Prerequisites>
     <Installation>
         <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Community" />
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 19.0)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
     </Installation>

--- a/Tests/ParallelBuildsMonitorTests.csproj
+++ b/Tests/ParallelBuildsMonitorTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ParallelBuildsMonitorTests</RootNamespace>
     <AssemblyName>ParallelBuildsMonitorTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>


### PR DESCRIPTION
With inspiration from https://github.com/KrzysztofBuchacz/ParallelBuildsMonitor/pull/58, I updated Plugin/source.extension.vsixmanifest to declare VS 2026 as compatible.

In my (currently only very short) experiments I didn't experience any real trouble when evaluating the extension on VS 2026 Insider - only that the first time I installed it, the extension window would not open and instead show some warning, but this hasn't happened since.

In the process VS automatically changed the target .NET version to 4.8 (because this one is available automatically I think); this seems to have no implications on functionality or code compatibility as far as I could determine, but I have to put up a caveat here that I don't have much experience with .NET!

Would "fix" [#62](https://github.com/KrzysztofBuchacz/ParallelBuildsMonitor/issues/62) - the extension works with and without the change, but with this fix, the extension manager does not report a warning about the extension as targeting an old VS version.